### PR TITLE
fix Ruby 3.0以降で#human_enum_name_forがArgumentErrorになる

### DIFF
--- a/lib/activerecord/enum_translation.rb
+++ b/lib/activerecord/enum_translation.rb
@@ -34,7 +34,7 @@ module ActiveRecord
 
       key = defaults.shift
       options[:default] = defaults.empty? ? nil : defaults
-      ::I18n.t(key, options)
+      ::I18n.t(key, **options)
     end
 
     module ClassMethods


### PR DESCRIPTION
# Summery

* Ruby 3.0 以降では  `::I18n.t(key,**options)` の書き方にしないと動かないので修正
* https://github.com/ruby-i18n/i18n/blob/master/lib/i18n.rb#L198

## 検証バージョン
* ruby 3.0.3p157
